### PR TITLE
Add BESZEL_AGENT_KEY to forgejo-runner .env template

### DIFF
--- a/roles/deploy_docker_env/templates/forgejo-runner.env.example
+++ b/roles/deploy_docker_env/templates/forgejo-runner.env.example
@@ -9,3 +9,6 @@ FORGEJO_INSTANCE_URL={{ docker_forgejo_instance_url }}
 # Navigate to: Site Administration → Actions → Runners
 # Click "Create new Runner" and copy the registration token
 FORGEJO_RUNNER_TOKEN={{ docker_forgejo_runner_token }}
+
+# Beszel Agent Key (for monitoring sidecar)
+BESZEL_AGENT_KEY={{ docker_beszel_agent_key }}


### PR DESCRIPTION
## Summary
- Adds `BESZEL_AGENT_KEY` variable to the forgejo-runner `.env.example` Jinja2 template
- Required by the beszel-agent monitoring sidecar added in docker_projects PR #26
- Resolves from vault via `docker_beszel_agent_key` (already mapped in `group_vars/all/docker_vars.yml`)

## Test plan
- [ ] Merge docker_projects PR #26 first (daemon + beszel-agent)
- [ ] Run `server_provision_script` against forgejo-runner host
- [ ] Verify `~/docker/.env` on target contains `BESZEL_AGENT_KEY`
- [ ] Verify beszel-agent container starts with valid key

🤖 Generated with [Claude Code](https://claude.com/claude-code)