### PR TITLE
fix: use external Uptime Kuma URL for github-backup heartbeat

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -24,6 +24,8 @@ gemini_primary_secret_key: "{{ vault_gemini_primary_secret_key}}"
 
 github_personal_access_token: "{{ vault_github_personal_access_token }}"
 
+uptime_kuma_github_backup_push_url: "{{ vault_uptime_kuma_github_backup_push_url }}"
+
 prowl_api_key: "{{ vault_prowl_api_key }}"
 
 voyager_private_ssh_key: "{{ vault_voyager_private_ssh_key }}"

--- a/roles/provision_dev_server/tasks/main.yml
+++ b/roles/provision_dev_server/tasks/main.yml
@@ -603,7 +603,7 @@
           name: github_backup
           minute: "0"
           hour: "4"
-          job: "github-backup KolinSmith -f {{ github_personal_access_token }} -o /home/{{ user }}/github_backups --repositories && curl -fsS -m 10 --retry 5 -o /dev/null 192.168.3.7:8013/ping/0e28c1ba-2933-4981-96f3-5a8634c93f2c"
+          job: "github-backup KolinSmith -f {{ github_personal_access_token }} -o /home/{{ user }}/github_backups --repositories && curl -fsS -m 10 --retry 5 -o /dev/null '{{ uptime_kuma_github_backup_push_url }}'"
         become_user: "{{ user }}"
 
       - name: create pia-wireguard-reregister job


### PR DESCRIPTION
## Summary

- Voyager (192.168.9.x) cannot reach Uptime Kuma at 192.168.3.7:8013 across VLANs — heartbeat ping was silently failing every night
- Switch cron job to use the external push URL via `uptime_kuma_github_backup_push_url`
- Expose `vault_uptime_kuma_github_backup_push_url` (already in vault) through `group_vars/all/vars.yml`

## Test plan

- [x] Manually pinged `https://uptime.hiddenba.se/api/push/iOqD6ATusK?status=up&msg=OK&ping=` from Voyager — HTTP 200, Uptime Kuma shows up
- [x] Live crontab on Voyager already updated to match
- [ ] Confirm Uptime Kuma shows success after 4 AM cron run

🤖 Generated with [Claude Code](https://claude.com/claude-code)